### PR TITLE
Fixed typo in package name causing Android build fail

### DIFF
--- a/src/android/NativeAudioAssetComplex.java
+++ b/src/android/NativeAudioAssetComplex.java
@@ -5,7 +5,7 @@
 //  Created by Sidney Bofah on 2014-06-26.
 //
 
-package com.rjfuin.cordova.plugin.nativeaudio;
+package com.rjfun.cordova.plugin.nativeaudio;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;


### PR DESCRIPTION
There was a typo in the package name of one of the Android Java files, causing app builds to fail. A very simple fix! :smile: 