### PR TITLE
Prevent NPE when stopping a looping sound

### DIFF
--- a/src/android/NativeAudioAssetComplex.java
+++ b/src/android/NativeAudioAssetComplex.java
@@ -162,6 +162,7 @@ public class NativeAudioAssetComplex implements OnPreparedListener, OnCompletion
 			this.state = INVALID;
 			try {
 				this.stop();
+				if (completeCallback != null)
                 completeCallback.call();
 			}
 			catch (Exception e)


### PR DESCRIPTION
When we stop a sound that is looping in the background, the completeCallback is not set.
Add conditional to prevent a NullPointerException.