### PR TITLE
Use valid XML in plugin.xml.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     version="3.0.7">
       
     <name>Cordova Native Audio</name>
-    <author>Andrew Trice, Raymond Xie, Sidney Bofah & other contributors</author>
+    <author>Andrew Trice, Raymond Xie, Sidney Bofah and other contributors</author>
 	<description>Cordova/PhoneGap Plugin for low latency Native Audio Playback, must have for HTML5 games</description>
     
 	<license>MIT</license>


### PR DESCRIPTION
Replace the `&` with `and` to make it valid XML.

Fixes #93.
