### PR TITLE
Removing the character '&' from config.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     version="3.0.7">
       
     <name>Cordova Native Audio</name>
-    <author>Andrew Trice, Raymond Xie, Sidney Bofah & other contributors</author>
+    <author>Andrew Trice, Raymond Xie, Sidney Bofah and other contributors</author>
 	<description>Cordova/PhoneGap Plugin for low latency Native Audio Playback, must have for HTML5 games</description>
     
 	<license>MIT</license>


### PR DESCRIPTION
I change '&' with 'and' because that character may create problems while parsing the config.xml

In my Ionic2 project I had to remove ios and put it back.
But I couldn't do it because of this error:

`Error parsing /Applications/my_project/alpha7/plugins/cordova-plugin-nativeaudio/plugin.xml.
Error: Invalid character in entity name
Line: 8
Column: 54`

After changing '&' with 'and' everything worked out fine.