### PR TITLE
Fix invalid XML error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ignore following files
 .settings
 .idea
+.vscode
 node_modules
 .tmp
 .sass-cache

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     version="3.0.7">
       
     <name>Cordova Native Audio</name>
-    <author>Andrew Trice, Raymond Xie, Sidney Bofah & other contributors</author>
+    <author>Andrew Trice, Raymond Xie, Sidney Bofah &amp; other contributors</author>
 	<description>Cordova/PhoneGap Plugin for low latency Native Audio Playback, must have for HTML5 games</description>
     
 	<license>MIT</license>


### PR DESCRIPTION
I had trouble installing this plugin with ionic cli, as the XML had an invalid character.

```
$ ionic plugin add --save cordova-plugin-nativeaudio
Fetching plugin "cordova-plugin-nativeaudio" via npm


Error: Invalid character in entity name
Line: 8
Column: 54
Char:
```

`&` by itself is not valid in XML and must be escaped by using `&amp;`.

I fixed this issue and now I can install the plugin via a git URL.