### PR TITLE
Fixed the Invalid Character error while installing plugin using cordova.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     version="3.0.7">
       
     <name>Cordova Native Audio</name>
-    <author>Andrew Trice, Raymond Xie, Sidney Bofah & other contributors</author>
+    <author>Andrew Trice, Raymond Xie, Sidney Bofah and other contributors</author>
 	<description>Cordova/PhoneGap Plugin for low latency Native Audio Playback, must have for HTML5 games</description>
     
 	<license>MIT</license>


### PR DESCRIPTION
While installing the module was getting below error. 

`Error: Failed to fetch plugin https://github.com/dhaval85/cordova-plugin-nativeaudio.git via git.
Either there is a connection problems, or plugin spec is incorrect:
	Error: Invalid character in entity name
Line: 8
Column: 54
Char:  `

Fixed it by removing the & character. 