### PR TITLE
Fix background music interruption on plugin init on Android and iOS

### DIFF
--- a/src/android/NativeAudio.java
+++ b/src/android/NativeAudio.java
@@ -201,14 +201,6 @@ public class NativeAudio extends CordovaPlugin implements AudioManager.OnAudioFo
 	}
 	@Override
 	protected void pluginInitialize() {
-		AudioManager am = (AudioManager)cordova.getActivity().getSystemService(Context.AUDIO_SERVICE);
-
-	        int result = am.requestAudioFocus(this,
-	                // Use the music stream.
-	                AudioManager.STREAM_MUSIC,
-	                // Request permanent focus.
-	                AudioManager.AUDIOFOCUS_GAIN);
-
 		// Allow android to receive the volume events
 		this.webView.setButtonPlumbedToJs(KeyEvent.KEYCODE_VOLUME_DOWN, false);
 		this.webView.setButtonPlumbedToJs(KeyEvent.KEYCODE_VOLUME_UP, false);

--- a/src/ios/NativeAudio.m
+++ b/src/ios/NativeAudio.m
@@ -29,10 +29,8 @@ NSString* INFO_VOLUME_CHANGED = @"(NATIVE AUDIO) Volume changed.";
 {
     self.fadeMusic = NO;
 
-    AudioSessionInitialize(NULL, NULL, nil , nil);
     AVAudioSession *session = [AVAudioSession sharedInstance];
     // we activate the audio session after the options to mix with others is set
-    [session setActive: NO error: nil];
     NSError *setCategoryError = nil;
 
     // Allows the application to mix its audio with audio from other apps.
@@ -43,9 +41,6 @@ NSString* INFO_VOLUME_CHANGED = @"(NATIVE AUDIO) Volume changed.";
         NSLog (@"Error setting audio session category.");
         return;
     }
-
-    [session setActive: YES error: nil];
-    [session setCategory:AVAudioSessionCategoryPlayback error:nil];
 }
 
 - (void) parseOptions:(NSDictionary*) options


### PR DESCRIPTION
This patch fixes background audio or music from other apps being interrupted when an app with this plugin was started, both on iOS and Android.

On iOS: Removed deprecated AudioSessionInitialize call and extra setCategory and setActive calls that where not really needed and where overriding the main initialization call.

On Android: removed the AudioManager requestAudioFocus call that is not really needed, playing audio will work fine without this call.
