### PR TITLE
removed android.permissions.READ_PHONE_STATE

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,6 @@
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-            <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
         </config-file>
 
     </platform>


### PR DESCRIPTION
This PR resolves https://github.com/floatinghotpot/cordova-plugin-nativeaudio/issues/112 issue.
After android sdk level 23 this permission is dangerous.