### PR TITLE
IOS - change to the session to allow mixing with other sound

### DIFF
--- a/src/ios/NativeAudio.m
+++ b/src/ios/NativeAudio.m
@@ -29,7 +29,6 @@ NSString* INFO_VOLUME_CHANGED = @"(NATIVE AUDIO) Volume changed.";
 {
     self.fadeMusic = NO;
 
-    AudioSessionInitialize(NULL, NULL, nil , nil);
     AVAudioSession *session = [AVAudioSession sharedInstance];
     // we activate the audio session after the options to mix with others is set
     [session setActive: NO error: nil];
@@ -44,8 +43,9 @@ NSString* INFO_VOLUME_CHANGED = @"(NATIVE AUDIO) Volume changed.";
         return;
     }
 
-    [session setActive: YES error: nil];
-    [session setCategory:AVAudioSessionCategoryPlayback error:nil];
+    [session setActive: YES withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error: nil];
+    [session setCategory:AVAudioSessionCategoryAmbient withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+
 }
 
 - (void) parseOptions:(NSDictionary*) options


### PR DESCRIPTION
Even with the existing fix that was supposed to fix this issue, the loading of audio would always stop any background music playing in other apps such as Spotify on IOS.

Now it should fade the background music and allow both sounds to mix.

I also removed a line which is no longer needed to init the session.