### PR TITLE
Fix iOS background music for another app

### DIFF
--- a/src/ios/NativeAudio.m
+++ b/src/ios/NativeAudio.m
@@ -45,7 +45,9 @@ NSString* INFO_VOLUME_CHANGED = @"(NATIVE AUDIO) Volume changed.";
     }
 
     [session setActive: YES error: nil];
-    [session setCategory:AVAudioSessionCategoryPlayback error:nil];
+    [session setCategory:AVAudioSessionCategoryPlayback
+             withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                  error:nil];
 }
 
 - (void) parseOptions:(NSDictionary*) options


### PR DESCRIPTION
This commit solves two errors detected:

1. iPhone 7 - iOS 9 and iPhone 5S iOS9:

With app in background after play music on Spotify, youtube or call someone, the app no sound more in background.

2. iPhone 5S iOS9:

After run stop in background the app no sound more in background.